### PR TITLE
fix: update 1Password client version from 637 to 945

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ export const g = "05";
 
 export const device: Device = {
   clientName: "1Password for Web",
-  clientVersion: "637",
+  clientVersion: "945",
   model: "73.0.3683.103",
   name: "Chrome",
   osName: "MacOSX",

--- a/src/services/Onepassword.ts
+++ b/src/services/Onepassword.ts
@@ -73,7 +73,7 @@ export class Onepassword {
     const message = {
       sessionID: this.session.id,
       clientVerifyHash,
-      client: "1Password for Web/637",
+      client: "1Password for Web/945",
       device: this.device
     };
     const { serverVerifyHash } = await this.requestService.secureRequest(

--- a/src/services/Request.ts
+++ b/src/services/Request.ts
@@ -27,7 +27,7 @@ export default class {
   ): Promise<any> {
     headers = {
       "x-requested-with": "XMLHttpRequest",
-      "x-agilebits-client": "1Password for Web/637",
+      "x-agilebits-client": "1Password for Web/945",
       "User-Agent":
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36",
       ...(method !== "GET" && { "Content-Type": "application/json" }),


### PR DESCRIPTION
The 1Password client version 637 has been deprecated.  This updates the
client version in the library to 945 so that it will continue to work.

fixes: [issue 7](https://github.com/privicy/onepassword-web-client/issues/7)